### PR TITLE
get_cp_ki() removed format

### DIFF
--- a/R/get_cp_ki.R
+++ b/R/get_cp_ki.R
@@ -24,14 +24,14 @@ get_cp_ki <- function(country = NULL,
                       ppp_version = 2017, # GC: default value like Stata
                       release_version = NULL,
                       api_version = "v1",
-                      format = c("arrow", "rds", "json", "csv"),
+                      #format = c("arrow", "rds", "json", "csv"),
                       simplify = TRUE,
                       server = NULL) {
 
 
   # 0. Match args ----
   api_version <- match.arg(api_version)
-  format <- match.arg(format)
+  #format <- match.arg(format)
 
   # 1. povline set-up ----
   # (GC: stata equivalent but no 2005 and default to 2.15)
@@ -58,7 +58,7 @@ get_cp_ki <- function(country = NULL,
     version         = version,
     ppp_version     = ppp_version,
     release_version = release_version,
-    format          = format,
+    #format          = format,
     server          = server,
     api_version     = api_version,
     endpoint        = "cp-key-indicators"


### PR DESCRIPTION
# Prework

* [ x] I understand and agree to the [contributing guidelines](https://github.com/worldbank/pipr/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an [issue](https://github.com/worldbank/pipr/issues) to discuss my idea with the maintainer.


# Summary

Removed format from get_cp_ki() as endpoint cp-ki-indicators does not take format argument. 
Only hashtagged, as we could change the endpoint later.
